### PR TITLE
APIからの情報の取得をxmlからjsonに変えたい。

### DIFF
--- a/app/models/api_request.rb
+++ b/app/models/api_request.rb
@@ -7,7 +7,9 @@ class ApiRequest
     key = ENV["ASAHI_KENSAKU_API"]
     title = "Title:%E3%83%89%E3%83%A9%E3%81%88%E3%82%82%E3%82%93" #ドラえもん
     release_date = "ReleaseDate:2010-01-10"
-    url = "http://54.92.123.84/search?q=#{title}%20AND%20#{release_date}&ackey=#{key}"
-    REXML::Document.new(open(url))
+    format = "wt=json"
+    url = URI.parse("http://54.92.123.84/search?q=#{title}%20AND%20#{release_date}&#{format}&ackey=#{key}")
+    json = Net::HTTP.get(url)
+    result = JSON.parse(json)
   end
 end

--- a/app/models/api_request.rb
+++ b/app/models/api_request.rb
@@ -1,6 +1,7 @@
 class ApiRequest
-  require 'rexml/document'
-  require 'open-uri'
+  require 'net/http'
+  require 'uri'
+  require 'json'
 
   def response
     key = ENV["ASAHI_KENSAKU_API"]

--- a/app/models/doraemon_question.rb
+++ b/app/models/doraemon_question.rb
@@ -1,7 +1,9 @@
 #しつもん！ドラえもん から問題と答えを取得する
 class DoraemonQuestion
   def question
-    api_response.elements['response/result/doc/Body']
+    require 'pry'
+    binding.pry
+    api_response["response"]["result"]["doc"][0]["Body"]
   end
 
   def answer
@@ -18,7 +20,7 @@ class DoraemonQuestion
   end
 
   def get_answer
-    body = api_response.elements['response/result/doc[2]/Body']
+    body = api_response["response"]["result"]["doc"][1]["Body"]
     body_splited = body.to_s.split('　')
   end
 end

--- a/app/models/doraemon_question.rb
+++ b/app/models/doraemon_question.rb
@@ -1,8 +1,6 @@
 #しつもん！ドラえもん から問題と答えを取得する
 class DoraemonQuestion
   def question
-    require 'pry'
-    binding.pry
     api_response["response"]["result"]["doc"][0]["Body"]
   end
 


### PR DESCRIPTION
% rails s
=> Booting WEBrick
=> Rails 4.1.6 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Notice: server is listening on all interfaces (0.0.0.0). Consider using 127.0.0.1 (--binding option)
=> Ctrl-C to shutdown server
[2014-10-28 15:24:55] INFO  WEBrick 1.3.1
[2014-10-28 15:24:55] INFO  ruby 2.1.2 (2014-05-08) [x86_64-darwin13.0]
[2014-10-28 15:24:55] INFO  WEBrick::HTTPServer#start: pid=16428 port=3000

Started GET "/" for 127.0.0.1 at 2014-10-28 15:25:00 +0900
  ActiveRecord::SchemaMigration Load (0.4ms)  SELECT "schema_migrations".\* FROM "schema_migrations"
Processing by KarutaController#index as HTML
Completed 500 Internal Server Error in 130ms

NoMethodError (undefined method `elements' for #<Hash:0x007fa06bdcb640>):
  app/models/doraemon_question.rb:4:in`question'
  app/controllers/karuta_controller.rb:6:in `index'

  Rendered /Users/enoyan/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/_source.erb (0.6ms)
  Rendered /Users/enoyan/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.4ms)
  Rendered /Users/enoyan/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.0ms)
  Rendered /Users/enoyan/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.1.6/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb within rescues/layout (25.3ms)
